### PR TITLE
Upgrade node-fetch to latest

### DIFF
--- a/isomorphic-fetch/package.json
+++ b/isomorphic-fetch/package.json
@@ -36,7 +36,7 @@
   "files": ["*.mjs", "*.cjs", "*.js", "*.d.ts"],
 
   "dependencies": {
-    "node-fetch": "^2.6.12",
-    "@types/node-fetch": "^2.2.6"
+    "node-fetch": "^3.3.2",
+    "@types/node-fetch": "^2.6.11"
   }
 }


### PR DESCRIPTION
node-fetch 2.x uses the deprecated punycode module. The new version is more compatible with Node's builtin `fetch` module and does not depend on punycode.

Closes https://github.com/libsql/isomorphic-ts/issues/4