### PR TITLE
Forward duplex option on fetchWithAgentSelection

### DIFF
--- a/isomorphic-fetch/node.js
+++ b/isomorphic-fetch/node.js
@@ -25,6 +25,7 @@ function fetchWithAgentSelection(resource, options = {}) {
             method: resource.method,
             headers: resource.headers,
             body: resource.body,
+            duplex: resource.duplex || "half",
             ...options
         };
     }


### PR DESCRIPTION
Currently, we get the following error when making requests on the  [libsql/hrana-client-ts](https://github.com/libsql/hrana-client-ts) repository:
> TypeError: RequestInit: duplex option is required when sending a body.

According to [this issue](https://github.com/nodejs/node/issues/46221), this option is required and, following the recommendation from this [Chrome for Developers' article](https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests#half_duplex), we're setting its value to `duplex: half` as its default value if not provided because it was the only available value [at least a year ago](https://github.com/nodejs/node/issues/46221#issuecomment-1518582946) so makes sense to use as the default value too.