### PR TITLE
Fix duplex error on CommonJS files

### DIFF
--- a/isomorphic-fetch/node.cjs
+++ b/isomorphic-fetch/node.cjs
@@ -27,6 +27,7 @@ function fetchWithAgentSelection(resource, options = {}) {
             method: resource.method,
             headers: resource.headers,
             body: resource.body,
+            duplex: resource.duplex || "half",
             ...options
         };
     }


### PR DESCRIPTION
Fix duplex error on CommonJS files because change was present only on the `.js` version.