### PR TITLE
fix: prioritize `deno` and `workerd` conditions over `node` condition

### DIFF
--- a/isomorphic-fetch/package.json
+++ b/isomorphic-fetch/package.json
@@ -26,9 +26,9 @@
     ".": {
       "import": {
         "bun": "./web.js",
-        "node": "./node.js",
         "deno": "./web.js",
         "workerd": "./web.js",
+        "node": "./node.js",
         "default": "./web.js"
       },
       "require": {


### PR DESCRIPTION
This one isn't a big deal but when using esbuild to bundle a Cloudflare Worker, I usually add the `workerd` [condition](https://esbuild.github.io/api/#conditions) to my esbuild config to get my dependencies to use worker-compatible versions. However, when using `@libsql/client/web`, the build fails with error `no such module 'node:http` which is imported in the [`node` export](https://github.com/libsql/isomorphic-ts/blob/c8b48e008edf38bc642c0dcc784943e84626a11f/isomorphic-fetch/package.json#L29) of `isomorphic-fetch`. To fix this, I add `platform: browser` to my config, forcing it to use the `web` export of isomorphic-fetch. 
 
 The build then fails with `could not resolve module node:crypto` (or any [compatible node builtin](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) as these don't exist in a browser environment. To fix this I have to externalise _all_ node builtins I may be using so my esbuild config ends up being:

```typescript
import esbuild from "esbuild";

esbuild.build({
	platform: "browser",
	external: ["node:crypto", "node:process", "node:async_hooks"],
	conditions: ["workerd"],
});
```

Dependencies may also be using node builtins internally so what I end up usually doing is:

```typescript
import esbuild from "esbuild";
import { builtinModules } from "node:module";

esbuild.build({
	platform: "browser",
	external: [...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
	conditions: ["workerd"],
});
```

This happens because of the ordering of the `export` in the package.json, where the `node` condition takes precedence over the `workerd` condition. This PR simply swaps the priority. Here's an excerpt from the [Conditional Export](https://nodejs.org/api/packages.html#conditional-exports) docs:

> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.

Not sure what side effects this change may cause so feel free to close it if it breaks something, would just be nice to not have to do this on every project using this with esbuild and have everything configurable with just `conditions`.